### PR TITLE
Add missing properties to types + Fix fetchAccountPositions response type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { DefaultQueryParams, OrderImpactBodyParams } from './types/params';
 import {
   AccountPositionsResponseType,
   AccountResponseType,
+  AccountsResponseType,
   BalanceResponseType,
   BrokerageAuthorizationTypeObjectResponseType,
   BrokerageAuthResponseType,
@@ -294,7 +295,7 @@ export class SnapTradeFetch {
   async fetchUserAccounts(
     { userId, userSecret }: DefaultQueryParams,
     options?: RequestOptionsType
-  ): Promise<AccountResponseType[]> {
+  ): Promise<AccountsResponseType> {
     const response = await request({
       endpoint: '/api/v1/accounts',
       method: 'get',
@@ -306,7 +307,7 @@ export class SnapTradeFetch {
         userId,
       },
     });
-    return response as Promise<AccountResponseType[]>;
+    return response as Promise<AccountsResponseType>;
   }
 
   /**

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -8,9 +8,13 @@ export interface CurrencyType {
 }
 export interface AccountType {
   id: string;
-  brokerage: string;
-  number: string;
+  brokerage_authorization: string;
+  portfolio_group: string;
   name: string;
+  number: string;
+  institution_name: string;
+  cash_restrictions: CashRestrictionType[];
+  created_date: string;
 }
 
 export interface BalanceType {

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -90,6 +90,10 @@ export interface AccountResponseType extends ResponseType {
   data: AccountType;
 }
 
+export interface AccountsResponseType extends ResponseType {
+  data: AccountType[];
+}
+
 export interface BalanceResponseType extends ResponseType {
   data: BalanceType[];
 }

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -97,8 +97,11 @@ export interface BalanceResponseType extends ResponseType {
 export interface AccountPositionsResponseType extends ResponseType {
   data: {
     symbol: SymbolType;
-    units: number;
     price: number;
+    open_pnl: number | null;
+    fractional_units: number | null;
+    units: number;
+    average_purchase_price: number;
   }[];
 }
 


### PR DESCRIPTION
- Missing properties `brokerage_authorization`,  `portfolio_group`, `institution_name`, `cash_restrictions` and `created_date` added to `AccountType`.
- Missing properties `fractional_units`, `open_pnl` and `average_purchase_price` added to `AccountPositionsResponseType`
- Fix response type from `fetchUserAccounts` by adding a new `AccountsResponseType` type.