### PR TITLE
Fix symbol property in AccountPositionsResponseType

### DIFF
--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -96,9 +96,14 @@ export interface BalanceResponseType extends ResponseType {
 
 export interface AccountPositionsResponseType extends ResponseType {
   data: {
-    symbol: SymbolType;
-    units: number;
+    symbol: {
+        symbol: SymbolType,
+    }
     price: number;
+    open_pnl: number | null;
+    fractional_units: number | null;
+    units: number;
+    average_purchase_price: number;
   }[];
 }
 


### PR DESCRIPTION
- Fix `symbol `property in `AccountPositionsResponseType`

As per the response from the API the top level `symbol` has another `symbol` child property.

```
{
  symbol: {
    symbol: {
      id: '69e08feb-99af-48eb-863a-7019c766f8c7',
      symbol: 'V',
      description: 'Visa Inc - Class A',
      currency: [Object],
      exchange: [Object],
      currencies: [],
      type: [Object]
    },
    id: 'b2268574-6099-4066-a50c-f9f35b82a3c0',
    description: '',
    local_id: '25596f9a-11d5-447b-a6d4-3f7fedbfed73',
    security_type: {},
    listing_exchange: {},
    is_quotable: true,
    is_tradable: true
  },
  price: 206.67,
  open_pnl: null,
  fractional_units: 1.94698668,
  currency: null,
  units: 1.947,
  average_purchase_price: 193.98
}
```