### PR TITLE
[FEAT] Add `fetchPerformanceInformation`, request, types and docs

### DIFF
--- a/docs/transaction-and-reporting-endpoints.md
+++ b/docs/transaction-and-reporting-endpoints.md
@@ -33,3 +33,39 @@ const getTransactionHistory = async () => {
   return transactionHistory;
 };
 ```
+
+### _performance information_
+
+Get performance information for a user
+
+##### Signature:
+
+```typescript
+fetchPerformanceInformation(
+    { userId, userSecret }: DefaultQueryParams,
+    extraParams: { startDate: string; endDate: string; accounts: string; frequency: string; detailed: boolean; },
+    { timeout }: RequestOptionsType,
+  ): Promise<PerformanceInformationResponseType[]>
+```
+
+##### Example:
+
+```typescript
+const getPerformanceInformation = async () => {
+  const performanceInformation = await snapTrade.fetchPerformanceInformation(
+    { timeout: 65000 }, // default timeout is 60000
+    {
+      userId: 'USER_ID',
+      userSecret: 'USER_SECRET',
+    },
+    {
+      startDate: '2022-01-24', //required
+      endDate: '2022-02-24', //required
+      accounts: '5a1066f1-1338-2418-b3ed-9c13a8ff76e1', //optional comma separated list of account IDs used to filter the request on specific accounts
+      detailed: false, //optional increases frequency of data points for the total value and contribution charts if set to true
+      frequency: 'daily',//optional frequency for the rate of return chart (defaults to monthly). Possible values are daily, weekly, monthly, quarterly, yearly.
+    }
+  );
+  return performanceInformation;
+};
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 import { request } from './request';
 import { RequestOptionsType } from './types/general';
-import { DefaultQueryParams, OrderImpactBodyParams } from './types/params';
+import {
+  DefaultQueryParams,
+  OrderImpactBodyParams,
+  PerformanceInformationQueryParams,
+} from './types/params';
 import {
   AccountPositionsResponseType,
   AccountResponseType,
@@ -27,6 +31,7 @@ import {
   UserHoldingsResponseType,
   RetrieveJWTResponseType,
   AccountHoldingsResponseType,
+  PerformanceInformationResponseType,
 } from './types/response';
 
 import { privateDecrypt, constants, createDecipheriv } from 'crypto';
@@ -896,5 +901,31 @@ export class SnapTradeFetch {
       extraParams,
     });
     return response as Promise<TransactionHistoryResponseType[]>;
+  }
+
+  /**
+   * Get performance information for a specific timeframe
+   * @param {DefaultQueryParams} defaultQueryParams
+   * @param {PerformanceInformationQueryParams} extraParams
+   * @returns Promise<PerformanceInformationResponseType[]>
+   */
+  async fetchPerformanceInformation(
+    { userId, userSecret }: DefaultQueryParams,
+    extraParams: PerformanceInformationQueryParams,
+    options?: RequestOptionsType
+  ): Promise<PerformanceInformationResponseType[]> {
+    const response = await request({
+      endpoint: '/api/v1/performance/custom',
+      method: 'get',
+      timeout: options?.timeout,
+      consumerKey: this.consumerKey,
+      defaultQueryParams: {
+        clientId: this.clientId,
+        userSecret,
+        userId,
+      },
+      extraParams,
+    });
+    return response as Promise<PerformanceInformationResponseType[]>;
   }
 }

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -57,7 +57,7 @@ export interface TradeType {
   id: string;
   account: AccountType;
   order_type: string;
-  time_in_force: 'FOK' | 'Day';
+  time_in_force: "FOK" | "Day";
   symbol: ManualTradeSymbolType;
   action: string;
   units: number;
@@ -68,7 +68,7 @@ export interface CashRestrictionType {
   id: string;
   account: string;
   currency: string;
-  type: 'ALLOCATE_MAX' | 'RETAIN_MIN';
+  type: "ALLOCATE_MAX" | "RETAIN_MIN";
   amount: number;
 }
 
@@ -126,7 +126,7 @@ export interface OrderType {
   limit_price: number;
   stop_price: number;
   order_type: string;
-  time_in_force: 'FOK' | 'Day';
+  time_in_force: "FOK" | "Day";
   time_placed: string;
   time_updated: string;
   expiry_date: string;
@@ -145,4 +145,76 @@ export interface OptionPosition {
   };
   price: number;
   currency: CurrencyType;
+}
+
+export interface Timeframe {
+  date: string;
+  value: number;
+  currency: string;
+}
+
+export interface Contribution {
+  contributions: number;
+  date: string;
+  currency: string;
+}
+
+export interface ReturnRateTimeframe {
+  periodStart: string;
+  periodEnd: string;
+  rateOfReturn: number;
+}
+
+export interface DividendsSymbolCurrency {
+  id: string;
+  code: string;
+  name: string;
+  include_in_rate_data: boolean;
+}
+
+export interface DividendsSymbolExchange {
+  id: string;
+  mic_code: string;
+  code: string;
+  name: string;
+  timezone: string;
+  start_time: string;
+  close_time: string;
+  suffix: null;
+  allows_cryptocurrency_symbols: boolean;
+}
+
+export interface DividendsSymbolType {
+  id: string;
+  code: string;
+  is_supported: boolean;
+  description: string;
+}
+
+export interface DividendsSymbol {
+  id: string;
+  symbol: string;
+  description: string;
+  currency: DividendsSymbolCurrency;
+  exchange: DividendsSymbolExchange;
+  currencies: any[];
+  type: DividendsSymbolType;
+  raw_symbol: string;
+}
+
+export interface Dividends {
+  symbol: DividendsSymbol;
+  amount: number;
+  currency: string;
+}
+
+export interface DividendsTimelineInfo {
+  symbol: string;
+  amount: number;
+  currency: string;
+}
+
+export interface DividendsTimeline {
+  date: string;
+  dividends: DividendsTimelineInfo[];
 }

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -12,3 +12,11 @@ export interface OrderImpactBodyParams {
   units: number;
   universal_symbol_id: string;
 }
+
+export interface PerformanceInformationQueryParams {
+  startDate: string;
+  endDate: string;
+  accounts?: string;
+  frequency?: "daily" | "weekly" | "monthly" | "quarterly" | "yearly";
+  detailed?: boolean;
+}

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -2,7 +2,10 @@ import {
   AccountType,
   BalanceType,
   BrokerageType,
+  Contribution,
   CurrencyType,
+  Dividends,
+  DividendsTimeline,
   InvestmentAccountType,
   ManualTradeSymbolType,
   OptionPosition,
@@ -10,7 +13,9 @@ import {
   PortfolioGroupPositionType,
   PortfolioGroupType,
   PositionType,
+  ReturnRateTimeframe,
   SymbolType,
+  Timeframe,
   TradeType,
   UniversalSymbolType,
 } from './general';
@@ -101,8 +106,8 @@ export interface BalanceResponseType extends ResponseType {
 export interface AccountPositionsResponseType extends ResponseType {
   data: {
     symbol: {
-        symbol: SymbolType,
-    }
+      symbol: SymbolType;
+    };
     price: number;
     open_pnl: number | null;
     fractional_units: number | null;
@@ -196,6 +201,31 @@ export interface TransactionHistoryResponseType extends ResponseType {
     trade_date: string;
     type: string;
     units: number;
+  };
+}
+
+export interface PerformanceInformationResponseType extends ResponseType {
+  data: {
+    totalEquityTimeframe: Timeframe[];
+    contributions: Contribution;
+    contributionTimeframe: Timeframe[];
+    contributionTimeframeCumulative: Timeframe[];
+    withdrawalTimeframe: Timeframe[];
+    contributionStreak: number;
+    contributionMonthsContributed: number;
+    contributionTotalMonths: number;
+    dividendIncome: number;
+    monthlyDividends: number;
+    dividends: Dividends[];
+    badTickers: any[];
+    dividendTimeline: DividendsTimeline[];
+    commissions: number;
+    forexFees: number;
+    fees: number;
+    feeSavings: number;
+    rateOfReturn: number;
+    returnRateTimeframe: ReturnRateTimeframe[];
+    detailedMode: boolean;
   };
 }
 


### PR DESCRIPTION
### Changes

This PR includes the following changes:

- add `fetchPerformanceInformation` function to fetch custom performance;
- update `transaction-and-reporting-endpoints.md` docs;
- add the following interfaces:
  - `PerformanceInformationQueryParams`
  - `Timeframe`
  - `Contribution`
  - `ReturnRateTimeframe`
  - `DividendsSymbolCurrency`
  - `DividendsSymbolExchange`
  - `DividendsSymbolType`
  - `DividendsSymbol`
  - `Dividends`
  - `DividendsTimelineInfo`
  - `DividendsTimeline`