### PR TITLE
fix: update exchange in symbol to align with API response

### DIFF
--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -195,7 +195,12 @@ export interface TransactionHistoryResponseType extends ResponseType {
       symbol: string;
       raw_symbol: string;
       currency: CurrencyType;
-      exchange: string | null;
+      exchange: {
+        code: string;
+        mic_code: string;
+        name: string;
+        suffix: string | null
+      } | null;
     };
     option_symbol: string | null;
     account: {


### PR DESCRIPTION
Fix current transaction mapping which has `exchange` mapped as `string | null` when it's actually an object.